### PR TITLE
UUID for S3 bucket names

### DIFF
--- a/.forge/deploy.sh
+++ b/.forge/deploy.sh
@@ -26,7 +26,8 @@ KEY_BASE="${1:-edmp-key}"                # default file name (no extension)
 PUB_KEY="${KEY_BASE}.pub"
 
 # Backend configuration - use existing or create with fixed names
-BUCKET_NAME="edmp-terraform-state-permanent"
+UUID=$(uuidgen -r)
+BUCKET_NAME="edmp-terraform-state-permanent-$UUID"
 DYNAMODB_TABLE="edmp-terraform-state-lock-permanent"
 REGION="us-west-1"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment process to use a uniquely named S3 bucket for Terraform backend, improving resource isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->