### PR TITLE
unique ssh key pairs

### DIFF
--- a/.forge/destroy.sh
+++ b/.forge/destroy.sh
@@ -29,18 +29,37 @@ echo "🔧  Using backend configuration:"
 echo "    S3 Bucket: $BUCKET_NAME"
 echo "    DynamoDB: $DYNAMODB_TABLE"
 echo "    Region: $REGION"
+echo "    Key Pair: ${KEY_PAIR_NAME:-edmp-key}"
 
 # ──────────────────────────────────────────────────────────────
 # 2️⃣  destroy terraform resources
 # ──────────────────────────────────────────────────────────────
 cd terraform
 
+# Get AWS credentials from CLI for Terraform (SSO workaround)
+echo "🔐  Setting up AWS credentials for Terraform..."
+eval "$(aws configure export-credentials --profile ${AWS_PROFILE:-default} --format env)"
+
 echo "⚠️  Destroying Terraform-managed resources..."
-terraform init -upgrade -input=false >/dev/null
-terraform destroy -auto-approve
+terraform init \
+  -backend-config="bucket=${BUCKET_NAME}" \
+  -backend-config="key=edmp/terraform.tfstate" \
+  -backend-config="region=${REGION}" \
+  -backend-config="encrypt=true" \
+  -backend-config="dynamodb_table=${DYNAMODB_TABLE}" \
+  -backend-config="workspace_key_prefix=edmp" \
+  -upgrade -input=false >/dev/null
+
+terraform destroy -var="aws_region=${REGION}" -var="key_pair_name=${KEY_PAIR_NAME:-edmp-key}" -auto-approve
 
 # ──────────────────────────────────────────────────────────────
-# 3️⃣  backend resources are NEVER deleted (they store terraform state)
+# 3️⃣  cleanup AWS key pair
+# ──────────────────────────────────────────────────────────────
+echo "🗑️  Deleting AWS key pair '${KEY_PAIR_NAME:-edmp-key}'..."
+aws ec2 delete-key-pair --key-name "${KEY_PAIR_NAME:-edmp-key}" --region "$REGION" 2>/dev/null || echo "    Key pair already deleted or not found."
+
+# ──────────────────────────────────────────────────────────────
+# 4️⃣  backend resources are NEVER deleted (they store terraform state)
 # ──────────────────────────────────────────────────────────────
 echo "ℹ️  Backend resources (S3 bucket and DynamoDB table) are preserved."
 echo "    These contain your terraform state and should never be deleted."
@@ -48,14 +67,16 @@ echo "    S3 Bucket: $BUCKET_NAME"
 echo "    DynamoDB: $DYNAMODB_TABLE"
 
 # ──────────────────────────────────────────────────────────────
-# 4️⃣  completion message
+# 5️⃣  completion message
 # ──────────────────────────────────────────────────────────────
 echo ""
 echo "✅  Terraform destroy complete."
 echo "🔑  Local SSH key-pair left untouched:"
 echo "    terraform/edmp-key      (private key)"
 echo "    terraform/edmp-key.pub  (public key)"
-echo "    Delete them manually if you no longer need SSH access."
+echo "🗑️  AWS key pair '${KEY_PAIR_NAME:-edmp-key}' has been deleted."
 echo ""
 echo "⚠️  IMPORTANT: Backend state resources are preserved and should never be deleted."
 echo "    They contain your terraform state and are required for future deployments."
+
+cd ..

--- a/.terraform-backend-info
+++ b/.terraform-backend-info
@@ -1,3 +1,4 @@
-BUCKET_NAME=edmp-terraform-state-permanent
-DYNAMODB_TABLE=edmp-terraform-state-lock-permanent
-REGION=us-west-1
+BUCKET_NAME=edmp-terraform-state-013364997013
+DYNAMODB_TABLE=edmp-terraform-state-lock
+REGION=us-east-1
+KEY_PAIR_NAME=edmp-key-f6a1d0a6

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -127,7 +127,7 @@ resource "aws_security_group" "edmp_container_sg" {
 
 # Reference the existing key pair (created by deploy.sh)
 data "aws_key_pair" "edmp_key" {
-  key_name = "edmp-key"
+  key_name = var.key_pair_name
 }
 
 # Get the latest Amazon Linux 2 AMI

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,3 +40,9 @@ variable "db_password" {
   sensitive   = true
   default     = "sonar123!"
 }
+
+variable "key_pair_name" {
+  description = "Name of the AWS key pair to use"
+  type        = string
+  default     = "edmp-key"
+}


### PR DESCRIPTION
should fix issue with VM deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now use a uniquely generated AWS EC2 key pair for each run, improving isolation and avoiding key conflicts.
  * The key pair name is consistently referenced and stored for downstream use.

* **Improvements**
  * Terraform configuration now allows the AWS key pair name to be set via a variable for greater flexibility.
  * Backend configuration and region details have been updated for Terraform state management.
  * Destroy operations now clean up the AWS key pair after resource deletion and provide clearer status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->